### PR TITLE
Implemented snapDataUrl()

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ myCamera.snap()
      // Handle your error
   });
 ```
+
+You may use the snapDataUrl method for capturing a photo in Data-URL format (i.e. for embedding it in a website) without saving it to disk.
+```javascript
+const PiCamera = require('pi-camera');
+const myCamera = new PiCamera({
+  mode: 'photo',
+  width: 640,
+  height: 480,
+  nopreview: true,
+});
+
+myCamera.snapDataUrl()
+  .then((result) => {
+    // Your picture was captured
+    console.log('<img src="${result}">');
+  })
+  .catch((error) => {
+     // Handle your error
+  });
+```
+
 ### Raspivid (Video Capture)
 ```javascript
 const PiCamera = require('pi-camera');

--- a/index.js
+++ b/index.js
@@ -48,6 +48,19 @@ class PiCamera {
     return Execute.run(Execute.cmd('raspistill', this.configToArray()));
   }
 
+  // Take a picture and return it in Data URL format (data:image/jpg;base64,...)
+  async snapDataUrl(maxBuffer = 1024*1024*10) {
+
+    if (this.mode !== 'photo') {
+      throw new Error(`snapDataUrl() can only be called when Pi-Camera is in 'photo' mode`);
+    }
+
+    this.config.output = '-';
+    const image = await Execute.run(Execute.cmd('raspistill', this.configToArray()), {encoding: 'binary', maxBuffer: maxBuffer});
+    let data = Buffer.from(image, 'binary').toString('base64');
+    return 'data:image/jpg;base64,' + data;
+  }
+
   // Record a video
   record() {
     if (this.mode !== 'video') {

--- a/lib/Execute.js
+++ b/lib/Execute.js
@@ -1,9 +1,9 @@
 const { exec } = require('child_process');
 
 class Execute {
-  static run(fullCmd) {
+  static run(fullCmd, options = {}) {
     return new Promise((resolve, reject) => {
-      exec(fullCmd, (error, stdout, stderr) => {
+      exec(fullCmd, options, (error, stdout, stderr) => {
         if (stderr || error) {
           reject(stderr || error);
         }


### PR DESCRIPTION
I wanted to `--output -` to capture a photo without saving it to disk. The result buffer was too small and the default utf8-encoding (instead of binary) was wrong, so I had to add options to Execute.run.

While being at it, I also added my snapDataUrl() method which will conveniently return a photo as `data:image/jpg;base64,...` URL.